### PR TITLE
Add token billing service and balance endpoint

### DIFF
--- a/app/domain/entities/session_data.go
+++ b/app/domain/entities/session_data.go
@@ -1,0 +1,9 @@
+package entities
+
+type SessionData struct {
+	SessionID             string `json:"session_id"`
+	TotalPromptTokens     int    `json:"total_prompt_tokens"`
+	TotalCompletionTokens int    `json:"total_completion_tokens"`
+	TotalTokens           int    `json:"total_tokens"`
+	RequestCount          int    `json:"request_count"`
+}

--- a/app/domain/services/token_billing_service.go
+++ b/app/domain/services/token_billing_service.go
@@ -1,0 +1,49 @@
+package services
+
+import (
+	"api/app/domain/entities"
+	"context"
+)
+
+type tokenCounterClient interface {
+	GetSessionData(ctx context.Context, sessionID string) (*entities.SessionData, error)
+}
+
+type balanceStorage interface {
+	GetBalance(ctx context.Context, apiKey string) (int, error)
+	SetBalance(ctx context.Context, apiKey string, balance int) error
+	GetTokenCost(ctx context.Context, tokenType string) (int, error)
+}
+
+type TokenBillingService struct {
+	counterClient tokenCounterClient
+	storage       balanceStorage
+}
+
+func NewTokenBillingService(counterClient tokenCounterClient, storage balanceStorage) *TokenBillingService {
+	return &TokenBillingService{counterClient: counterClient, storage: storage}
+}
+
+func (s *TokenBillingService) UpdateBalanceForSession(ctx context.Context, apiKey, sessionID string) error {
+	if apiKey == "" || sessionID == "" {
+		return nil
+	}
+	data, err := s.counterClient.GetSessionData(ctx, sessionID)
+	if err != nil {
+		return err
+	}
+	inputCost, err := s.storage.GetTokenCost(ctx, "input")
+	if err != nil {
+		return err
+	}
+	outputCost, err := s.storage.GetTokenCost(ctx, "output")
+	if err != nil {
+		return err
+	}
+	totalCost := data.TotalPromptTokens*inputCost + data.TotalCompletionTokens*outputCost
+	balance, err := s.storage.GetBalance(ctx, apiKey)
+	if err != nil {
+		return err
+	}
+	return s.storage.SetBalance(ctx, apiKey, balance-totalCost)
+}

--- a/app/domain/usecases/get_balance_usecase.go
+++ b/app/domain/usecases/get_balance_usecase.go
@@ -1,0 +1,19 @@
+package usecases
+
+import "context"
+
+type balanceStorage interface {
+	GetBalance(ctx context.Context, apiKey string) (int, error)
+}
+
+type GetBalanceUsecase struct {
+	storage balanceStorage
+}
+
+func NewGetBalanceUsecase(storage balanceStorage) *GetBalanceUsecase {
+	return &GetBalanceUsecase{storage: storage}
+}
+
+func (uc *GetBalanceUsecase) GetBalance(ctx context.Context, apiKey string) (int, error) {
+	return uc.storage.GetBalance(ctx, apiKey)
+}

--- a/app/internal/config/config.go
+++ b/app/internal/config/config.go
@@ -14,10 +14,13 @@ type Config struct {
 	CardCraftAi struct {
 		APIURL string `env:"CARD_CRAFT_AI_API_URL" env-required:"true"`
 	}
-	WB struct {
-		GetCardListMaxAttempts int `env:"WB_GET_CARD_LIST_MAX_ATTEMPTS" env-default:"3"`
-	}
-	HTTP struct {
+       WB struct {
+               GetCardListMaxAttempts int `env:"WB_GET_CARD_LIST_MAX_ATTEMPTS" env-default:"3"`
+       }
+       TokenCounter struct {
+               APIURL string `env:"TOKEN_COUNTER_API_URL" env-required:"true"`
+       }
+       HTTP struct {
 		Port int `env:"PORT" env-default:"8080"`
 	}
 	PostgreSQL struct {

--- a/app/internal/infrastructure/external/token_counter/client.go
+++ b/app/internal/infrastructure/external/token_counter/client.go
@@ -1,0 +1,41 @@
+package token_counter
+
+import (
+	"api/app/domain/entities"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+type Client struct {
+	baseURL    string
+	httpClient *http.Client
+}
+
+func NewClient(baseURL string) *Client {
+	return &Client{baseURL: baseURL, httpClient: http.DefaultClient}
+}
+
+func (c *Client) GetSessionData(ctx context.Context, sessionID string) (*entities.SessionData, error) {
+	url := fmt.Sprintf("%s/v1/session/%s/status", c.baseURL, sessionID)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("unexpected status %d: %s", resp.StatusCode, string(body))
+	}
+	var data entities.SessionData
+	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+		return nil, err
+	}
+	return &data, nil
+}

--- a/app/internal/infrastructure/persistence/postgres/balance_storage.go
+++ b/app/internal/infrastructure/persistence/postgres/balance_storage.go
@@ -35,3 +35,14 @@ func (s *BalanceStorage) SetBalance(ctx context.Context, apiKey string, balance 
 	_, err := s.client.Exec(ctx, query, apiKey, balance)
 	return err
 }
+
+// GetTokenCost returns token cost for the specified token type.
+func (s *BalanceStorage) GetTokenCost(ctx context.Context, tokenType string) (int, error) {
+	const query = "SELECT cost FROM token_costs WHERE token_type = $1"
+	row := s.client.QueryRow(ctx, query, tokenType)
+	var cost int
+	if err := row.Scan(&cost); err != nil {
+		return 0, err
+	}
+	return cost, nil
+}

--- a/app/internal/presentation/balance_handler.go
+++ b/app/internal/presentation/balance_handler.go
@@ -1,0 +1,47 @@
+package presentation
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+)
+
+type balanceUsecase interface {
+	GetBalance(ctx context.Context, apiKey string) (int, error)
+}
+
+type BalanceHandler struct {
+	usecase balanceUsecase
+}
+
+func NewBalanceHandler(uc balanceUsecase) *BalanceHandler {
+	return &BalanceHandler{usecase: uc}
+}
+
+func (h *BalanceHandler) GetBalance(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	authHeader := r.Header.Get("Authorization")
+	if authHeader == "" {
+		http.Error(w, "Authorization header required", http.StatusBadRequest)
+		return
+	}
+	const bearerPrefix = "Bearer "
+	if len(authHeader) <= len(bearerPrefix) || authHeader[:len(bearerPrefix)] != bearerPrefix {
+		http.Error(w, "invalid Authorization header", http.StatusBadRequest)
+		return
+	}
+	apiKey := authHeader[len(bearerPrefix):]
+
+	balance, err := h.usecase.GetBalance(r.Context(), apiKey)
+	if err != nil {
+		http.Error(w, "Internal server error", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]int{"balance": balance})
+}

--- a/app/internal/presentation/create_product_card_handler.go
+++ b/app/internal/presentation/create_product_card_handler.go
@@ -11,7 +11,7 @@ import (
 )
 
 type CreateCardUsecase interface {
-	CreateProductCard(ctx context.Context, req entities.ProductCard) (*entities.CreateProductCardResult, error)
+	CreateProductCard(ctx context.Context, apiKey string, req entities.ProductCard) (*entities.CreateProductCardResult, error)
 }
 
 type CreateProductCardHandler struct {
@@ -72,7 +72,14 @@ func (h *CreateProductCardHandler) CreateProductCard(ctx context.Context, req *c
 		OzonApiKey:           req.Msg.OzonApiKey,
 	}
 
-	createProductCardResult, err := h.createCardUsecase.CreateProductCard(ctx, productCard)
+	authHeader := req.Header().Get("Authorization")
+	const bearerPrefix = "Bearer "
+	apiKey := ""
+	if len(authHeader) > len(bearerPrefix) && authHeader[:len(bearerPrefix)] == bearerPrefix {
+		apiKey = authHeader[len(bearerPrefix):]
+	}
+
+	createProductCardResult, err := h.createCardUsecase.CreateProductCard(ctx, apiKey, productCard)
 	if err != nil {
 		return nil, err
 	}

--- a/schema/000001_init.down.sql
+++ b/schema/000001_init.down.sql
@@ -1,0 +1,2 @@
+DROP TABLE IF EXISTS token_costs;
+DROP TABLE IF EXISTS api_key_balances;

--- a/schema/000001_init.up.sql
+++ b/schema/000001_init.up.sql
@@ -1,0 +1,9 @@
+CREATE TABLE IF NOT EXISTS api_key_balances (
+    api_key TEXT PRIMARY KEY,
+    balance INT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS token_costs (
+    token_type TEXT PRIMARY KEY,
+    cost INT NOT NULL
+);


### PR DESCRIPTION
## Summary
- add database migrations for balances and token costs
- extend BalanceStorage with token cost retrieval
- implement token counter client and billing service
- update CreateCardUsecase to deduct balance based on token usage
- expose GET `/balance` endpoint
- support token counter API URL in config
- accept API key from Authorization header instead of query or body

## Testing
- `go vet ./...` *(fails: downloading modules forbidden)*
- `go test ./...` *(fails: downloading modules forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6844c10d9a3c832cbb717e94e6c53984